### PR TITLE
Update tire pressure formula. Reduce max values for tire pressures and odometer.

### DIFF
--- a/signalsets/v3/default.json
+++ b/signalsets/v3/default.json
@@ -1,19 +1,19 @@
 { "commands": [
 { "hdr": "726", "rax": "72E", "fcm1": true, "cmd": {"22": "2813"}, "freq": 15,
   "signals": [
-    {"id": "FUSION_TP_FL", "path": "Tires", "fmt": { "len": 16, "max": 255, "mul": 0.05, "unit": "psi" }, "name": "Front left tire pressure", "suggestedMetric": "frontLeftTirePressure"}
+    {"id": "FUSION_TP_FL", "path": "Tires", "fmt": { "len": 16, "max": 255, "div": 20, "unit": "psi" }, "name": "Front left tire pressure", "suggestedMetric": "frontLeftTirePressure"}
   ]},
 { "hdr": "726", "rax": "72E", "fcm1": true, "cmd": {"22": "2814"}, "freq": 15,
   "signals": [
-    {"id": "FUSION_TP_FR", "path": "Tires", "fmt": { "len": 16, "max": 255, "mul": 0.05, "unit": "psi" }, "name": "Front right tire pressure", "suggestedMetric": "frontRightTirePressure"}
+    {"id": "FUSION_TP_FR", "path": "Tires", "fmt": { "len": 16, "max": 255, "div": 20, "unit": "psi" }, "name": "Front right tire pressure", "suggestedMetric": "frontRightTirePressure"}
   ]},
 { "hdr": "726", "rax": "72E", "fcm1": true, "cmd": {"22": "2815"}, "freq": 15,
   "signals": [
-    {"id": "FUSION_TP_RR", "path": "Tires", "fmt": { "len": 16, "max": 255, "mul": 0.05, "unit": "psi" }, "name": "Rear right tire pressure", "suggestedMetric": "rearRightTirePressure"}
+    {"id": "FUSION_TP_RR", "path": "Tires", "fmt": { "len": 16, "max": 255, "div": 20, "unit": "psi" }, "name": "Rear right tire pressure", "suggestedMetric": "rearRightTirePressure"}
   ]},
 { "hdr": "726", "rax": "72E", "fcm1": true, "cmd": {"22": "2816"}, "freq": 15,
   "signals": [
-    {"id": "FUSION_TP_RL", "path": "Tires", "fmt": { "len": 16, "max": 255, "mul": 0.05, "unit": "psi" }, "name": "Rear left tire pressure", "suggestedMetric": "rearLeftTirePressure"}
+    {"id": "FUSION_TP_RL", "path": "Tires", "fmt": { "len": 16, "max": 255, "div": 20, "unit": "psi" }, "name": "Rear left tire pressure", "suggestedMetric": "rearLeftTirePressure"}
   ]},
 { "hdr": "7E0", "rax": "7E8", "fcm1": true, "cmd": {"22": "DD01"}, "freq": 5,
   "signals": [

--- a/signalsets/v3/default.json
+++ b/signalsets/v3/default.json
@@ -17,7 +17,7 @@
   ]},
 { "hdr": "7E0", "rax": "7E8", "fcm1": true, "cmd": {"22": "DD01"}, "freq": 5,
   "signals": [
-    {"id": "FUSION_ODO", "path": "Trips", "fmt": { "len": 24, "max": 4294967295, "unit": "kilometers" }, "name": "Odometer", "suggestedMetric": "odometer"}
+    {"id": "FUSION_ODO", "path": "Trips", "fmt": { "len": 24, "max": 16777215, "unit": "kilometers" }, "name": "Odometer", "suggestedMetric": "odometer"}
   ]}
 ]
 }

--- a/signalsets/v3/default.json
+++ b/signalsets/v3/default.json
@@ -1,19 +1,19 @@
 { "commands": [
 { "hdr": "726", "rax": "72E", "fcm1": true, "cmd": {"22": "2813"}, "freq": 15,
   "signals": [
-    {"id": "FUSION_TP_FL", "path": "Tires", "fmt": { "len": 16, "max": 65535, "div": 3, "add": 7.3, "unit": "kilopascal" }, "name": "Front left tire pressure", "suggestedMetric": "frontLeftTirePressure"}
+    {"id": "FUSION_TP_FL", "path": "Tires", "fmt": { "len": 16, "max": 255, "mul": 0.05, "unit": "psi" }, "name": "Front left tire pressure", "suggestedMetric": "frontLeftTirePressure"}
   ]},
 { "hdr": "726", "rax": "72E", "fcm1": true, "cmd": {"22": "2814"}, "freq": 15,
   "signals": [
-    {"id": "FUSION_TP_FR", "path": "Tires", "fmt": { "len": 16, "max": 65535, "div": 3, "add": 7.3, "unit": "kilopascal" }, "name": "Front right tire pressure", "suggestedMetric": "frontRightTirePressure"}
+    {"id": "FUSION_TP_FR", "path": "Tires", "fmt": { "len": 16, "max": 255, "mul": 0.05, "unit": "psi" }, "name": "Front right tire pressure", "suggestedMetric": "frontRightTirePressure"}
   ]},
 { "hdr": "726", "rax": "72E", "fcm1": true, "cmd": {"22": "2815"}, "freq": 15,
   "signals": [
-    {"id": "FUSION_TP_RR", "path": "Tires", "fmt": { "len": 16, "max": 65535, "div": 3, "add": 7.3, "unit": "kilopascal" }, "name": "Rear right tire pressure", "suggestedMetric": "rearRightTirePressure"}
+    {"id": "FUSION_TP_RR", "path": "Tires", "fmt": { "len": 16, "max": 255, "mul": 0.05, "unit": "psi" }, "name": "Rear right tire pressure", "suggestedMetric": "rearRightTirePressure"}
   ]},
 { "hdr": "726", "rax": "72E", "fcm1": true, "cmd": {"22": "2816"}, "freq": 15,
   "signals": [
-    {"id": "FUSION_TP_RL", "path": "Tires", "fmt": { "len": 16, "max": 65535, "div": 3, "add": 7.3, "unit": "kilopascal" }, "name": "Rear left tire pressure", "suggestedMetric": "rearLeftTirePressure"}
+    {"id": "FUSION_TP_RL", "path": "Tires", "fmt": { "len": 16, "max": 255, "mul": 0.05, "unit": "psi" }, "name": "Rear left tire pressure", "suggestedMetric": "rearLeftTirePressure"}
   ]},
 { "hdr": "7E0", "rax": "7E8", "fcm1": true, "cmd": {"22": "DD01"}, "freq": 5,
   "signals": [


### PR DESCRIPTION
@jverkoey  suggested testing this simplified scaling factor to convert the tire pressures directly to PSI. The readings appear to be slightly more accurate, and this reduces the number of conversions needed to get the commonly localized measurement unit.

Reduced the max values across the whole file because they were all ridiculously high.